### PR TITLE
collapsable: add/remove collapsed class

### DIFF
--- a/src/extension/features/general/collapse-side-menu/index.js
+++ b/src/extension/features/general/collapse-side-menu/index.js
@@ -59,6 +59,7 @@ export class CollapseSideMenu extends Feature {
         $('.ynab-u.content').animate({ left: '3rem' }).promise(),
         $('.budget-header').animate({ left: '3rem' }).promise()
       ]).then(() => {
+        $('.layout.user-logged-in').addClass('collapsed');
         $('.ynabtk-navlink-reports-link span').addClass('ynabtk-nav-link-collapsed');
         $('.ynabtk-collapse-link span').addClass('ynabtk-nav-link-collapsed');
         $('.ynabtk-collapse-icon').removeClass('left-circle-4').addClass('right-circle-4');
@@ -70,6 +71,7 @@ export class CollapseSideMenu extends Feature {
         $('.ynab-u.content').animate({ left: '260px' }).promise(),
         $('.budget-header').animate({ left: '260px' }).promise()
       ]).then(() => {
+        $('.layout.user-logged-in').removeClass('collapsed');
         $('.ynabtk-navlink-reports-link span').removeClass('ynabtk-nav-link-collapsed');
         $('.ynabtk-collapse-link span').removeClass('ynabtk-nav-link-collapsed');
         $('.ynabtk-collapse-icon').removeClass('right-circle-4').addClass('left-circle-4');


### PR DESCRIPTION
Actually set collapsed as a class on .layout.ember-view as to correctly correct issues with too narrow collapsed views, which arguably is the most important part of being able to collapse the view: gaining the most space when you're low on it. ;-)

Github Issue (if applicable): #XXX

Trello Link (if applicable):

Forum Link (if applicable):

#### Explanation of Bugfix/Feature/Enhancement:



#### Recommended Release Notes:
